### PR TITLE
release: 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ acceleration where the underlying algorithms admit it.
 
 ## Status
 
-Early development. The public API and ABI are unstable until 1.0.
+**1.0.0** — public API and ABI are stable. SONAME is `libksuid.so.1`;
+subsequent 1.x releases stay binary-compatible (semver). A breaking
+ABI change would require a 2.0 with a new SONAME.
 
 ## Goals
 
@@ -68,9 +70,14 @@ A release build on x86_64 produces (post-`strip --strip-unneeded`):
 
 | Artifact            | Bytes  |
 | :------------------ | -----: |
-| libksuid.so.0.1.0   | 18 560 |
-| libksuid.a          | 24 804 |
-| ksuid-gen (CLI)     | 27 464 |
+| libksuid.so.1.0.0   | 26 752 |
+| libksuid.a          | 35 212 |
+| ksuid-gen (CLI)     | 22 920 |
+
+The bulk-encode AVX2 kernel from `libksuid/encode_avx2.c` accounts for
+roughly 8 KB of the shared-library size; non-AVX2 hosts compile and
+link the kernel but never call into it, so the CPUID-gated dispatch
+adds no runtime cost to those targets.
 
 The shared library has zero runtime dependencies beyond the C library
 and, on Windows, `bcrypt.lib`.

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('libksuid', 'c',
-  version : '0.1.0',
+  version : '1.0.0',
   license : 'LGPL-3.0-or-later AND MIT',
   meson_version : '>=1.1.0',
   default_options : [
@@ -237,7 +237,10 @@ ksuid_lib = both_libraries('ksuid', core_sources,
   dependencies        : extra_link_deps,
   link_whole          : avx2_lib_dep,
   version             : meson.project_version(),
-  soversion           : '0',
+  # soversion tracks semver major: a major bump means a binary-
+  # incompatible ABI break and the SONAME flips with it. 1.0 is the
+  # first stable ABI commitment.
+  soversion           : '1',
   install             : true,
 )
 

--- a/tests/test_smoke.c
+++ b/tests/test_smoke.c
@@ -88,10 +88,10 @@ test_version_macros_are_consistent (void)
    *
    * When you bump meson.build's project version you MUST update
    * these four asserts in the same commit. */
-  ASSERT_EQ_INT (KSUID_VERSION_MAJOR, 0);
-  ASSERT_EQ_INT (KSUID_VERSION_MINOR, 1);
+  ASSERT_EQ_INT (KSUID_VERSION_MAJOR, 1);
+  ASSERT_EQ_INT (KSUID_VERSION_MINOR, 0);
   ASSERT_EQ_INT (KSUID_VERSION_PATCH, 0);
-  ASSERT_EQ_STR (KSUID_VERSION_STRING, "0.1.0");
+  ASSERT_EQ_STR (KSUID_VERSION_STRING, "1.0.0");
 
   /* The composite KSUID_VERSION must equal the documented
    * (MAJOR << 16) | (MINOR << 8) | PATCH layout for `#if


### PR DESCRIPTION
## Summary

First stable release. Public API + ABI move under semver from this
PR forward.

- meson project version `0.1.0` → `1.0.0`
- `both_libraries` soversion `0` → `1` (SONAME → `libksuid.so.1`)
- `tests/test_smoke.c` version-macro sync point updated (the
  deliberate compile-time check that `@VERSION_*@` substitution flows
  through `configure_file` into `ksuid_version.h`)
- README status section: drops "early development" wording, documents
  SONAME stability
- README footprint table: re-measured stripped sizes for x86_64

Cumulative scope landed across 0.x and shipping in 1.0.0:

- 20-byte / 27-char wire-compatible KSUID encode/decode
- Lock-free per-thread ChaCha20 CSPRNG with bounded reseed and
  DSE-resistant wipe (issue #2) + automatic thread-exit wipe via
  `__cxa_thread_atexit_impl` / `FlsAlloc` (issue #4)
- SSE2/NEON-accelerated input validation + 20-byte compare
- AVX2 8-wide `ksuid_string_batch` with CPUID-gated dispatch (issue #13)
- meson + ninja build, both static and shared libraries, `ksuid-gen` CLI
- Cross-platform RNG: `getrandom` (Linux), `getentropy` (macOS),
  `BCryptGenRandom` (Windows), `/dev/urandom` fallback

Issue #7 (CompressedSet) is permanently deferred and intentionally
NOT in 1.x scope.

## Test plan

- [x] `meson test -C build-release` — 16/16 pass
- [x] `ksuid-gen` smoke: upstream sample
  `0ujtsYcgvSTl8PAuAdqWYSMnLOv` → `0669F7EFB5A1CD34B5F99D1154FB6853345C9735`
- [x] `tools/gst-indent` clean
- [ ] CI matrix passes (Linux GCC/Clang, macOS, MSVC, ARM cross)
- [ ] Tag `v1.0.0` on the merge commit and create GitHub release

After merge: tag `v1.0.0` on the merge commit on `main`, then push
the tag to trigger any release-publishing workflow.